### PR TITLE
Fix mutation chunk loop

### DIFF
--- a/Assets/Scripts/Util/Mutation.cs
+++ b/Assets/Scripts/Util/Mutation.cs
@@ -99,9 +99,12 @@ namespace Keiwando.Evolution {
         private static T MutateChunk<T, E>(T chromosome, Mutate<E> mutate) where T: IMutatable<E> {
 
             int start = UnityEngine.Random.Range(0, chromosome.Length - 1);
-            int length = Math.Min(Math.Max(0, chromosome.Length - start - 3), UnityEngine.Random.Range(2, 15));
+            int length = Math.Min(
+                Math.Max(0, chromosome.Length - start - 3),
+                UnityEngine.Random.Range(2, 15)
+            );
 
-            for (int i = start; i < length; i++) {
+            for (int i = start; i < start + length; i++) {
                 chromosome[i] = mutate(chromosome[i]);
             }
 


### PR DESCRIPTION
## Summary
- fix bug in Mutation.MutateChunk so that the loop iterates over the correct range

## Testing
- `pytest -q` *(fails: command not found)*

## Summary by Sourcery

Fix the iteration range in MutateChunk to correctly apply mutations over the intended chunk and improve readability of the length calculation.

Bug Fixes:
- Adjust the for-loop upper bound to use start + length instead of length

Enhancements:
- Reformat the length calculation into a multi-line expression for clarity