### PR TITLE
Fix ChromosomeStats parsing

### DIFF
--- a/Assets/Scripts/Data/ChromosomeStats.cs
+++ b/Assets/Scripts/Data/ChromosomeStats.cs
@@ -16,12 +16,18 @@ public struct ChromosomeStats {
 		return string.Format("{0}:{1}", chromosome, stats.Encode());
 	}
 
-	public static ChromosomeStats FromString(string str) {
+        public static ChromosomeStats FromString(string str) {
 
-		var parts = str.Split(':');
+                var separatorIndex = str.IndexOf(':');
+                if (separatorIndex < 0) {
+                        throw new FormatException("Invalid ChromosomeStats string: missing separator");
+                }
 
-		return new ChromosomeStats(parts[0], CreatureStats.Decode(parts[1]));
-	}
+                var chromosome = str.Substring(0, separatorIndex);
+                var statsEncoded = str.Substring(separatorIndex + 1);
+
+                return new ChromosomeStats(chromosome, CreatureStats.Decode(statsEncoded));
+        }
 }
 
 


### PR DESCRIPTION
## Summary
- fix parsing of ChromosomeStats strings by handling only the first colon

## Testing
- `echo "No tests to run"`

## Summary by Sourcery

Fix parsing of ChromosomeStats strings by splitting only on the first colon and adding error handling for missing separators.

Bug Fixes:
- Prevent incorrect splitting by only using the first colon when parsing ChromosomeStats strings.

Enhancements:
- Throw a FormatException when the input string lacks the required separator.